### PR TITLE
Implementation of tables ADT and prioritized sweeping

### DIFF
--- a/gym_env/gym_env/envs/grid_world.py
+++ b/gym_env/gym_env/envs/grid_world.py
@@ -18,8 +18,8 @@ class GridWorldEnv(gym.Env):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 100000}
 
     def __init__(self, render_mode=None):
-        self.size_x = 10#  48
-        self.size_y = 10#  17
+        self.size_x = 48
+        self.size_y = 17
         self.block_size = 20
         self.window_width = self.size_x * self.block_size
         self.window_height = self.size_y * self.block_size

--- a/main.py
+++ b/main.py
@@ -82,11 +82,11 @@ def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
 
                 	# P <- abs(R + discount_factor * max(Q(S, a)) - Q(S_hat,A_hat))
                     priority = abs(predicted_reward + discount_factor * max(Q.get_action_values(state=(x1, y1), actions=[0, 1, 2, 3]).values()) - \
-                        Q[(x2, y2), act_from_sbar_to_s])
+                        Q[(xbar, ybar), act_from_sbar_to_s])
 
                     # if P > theta (assume 0?) then insert S_hat, A_hat into PQueue with priority P
                     if priority > 0:
-                        PQueue.insert((xbar, ybar), act, priority)
+                        PQueue.insert((xbar, ybar), act_from_sbar_to_s, priority)
                     
             curr_state = next_state
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
     C = tables.StateActionTable(default_value=0)
     T = tables.TTable()
     PQueue = pqueue.StateActionPQueue()
+    q_updates_count = 0
 
     heatmap = np.full((Ss[1], Ss[0]), fill_value=0, dtype=int)
 
@@ -76,6 +77,7 @@ def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
 
                     Q[(x1, y1), act] += discount_factor * (T[(x1, y1), act, (x2, y2)] / C[(x1, y1), act]) * \
                                 max(Q.get_action_values(state=(x2, y2), actions=[0, 1, 2, 3]).values())
+                    q_updates_count += 1
 
                 for (xbar, ybar), act_from_sbar_to_s in T.get_state_actions_with_access_to((x1, y1)):
                     predicted_reward = R[(xbar, ybar), act_from_sbar_to_s]
@@ -104,7 +106,7 @@ def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
             plt.pause(0.00001)
 
         print(
-            f"Episode #{episode} complete with a total reward of {round(total_episode_reward, 2)}. Target found? {terminated}"
+            f"Episode #{episode} complete with a total reward of {round(total_episode_reward, 2)}. Target found? {terminated}. Q table accesses is at {q_updates_count}"
         )
 
 

--- a/main.py
+++ b/main.py
@@ -51,35 +51,39 @@ def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
             # naive implementation - super inefficient and slow
             # updates every entry of the Q table after every action
             # (a literal implementation of fig 12.6 from https://artint.info/2e/html/ArtInt2e.Ch12.S8.html)
-            for (x1, y1) in T.get_states_accessible_from(tuple(curr_state)):
+            for (x1, y1) in C.get_all_states():
                 for act in range(4):
                     if C[(x1, y1), act] == 0:
                         continue
 
                     Q[(x1, y1), act] = R[(x1, y1), act]
 
-                    for (x2, y2) in T.get_states_accessible_from(tuple(curr_state)):
+                    for (x2, y2) in T.get_states_accessible_from((x1, y1)):
                         Q[(x1, y1), act] += discount_factor * (T[(x1, y1), act, (x2, y2)] / C[(x1, y1), act]) * \
-                                Q.get_best_action(state=(x2, y2), actions=[0, 1, 2, 3])
+                                max(Q.get_action_values(state=(x2, y2), actions=[0, 1, 2, 3]).values())
 
             curr_state = next_state
 
             if terminated or t >= MAX_TRY:
                 break
 
+            # display perceived values
+            q_ax[0].cla()
+            q_ax[1].cla()
+            value_map = (Q.convert_to_np_arr(Ss + (As,), 100)).max(axis=2).transpose()
+            q_ax[0].set_title('perceived state values (max Q values)')
+            q_ax[1].set_title('agent heat map')
+            q_ax[0].imshow(value_map)
+            q_ax[1].imshow(heatmap, cmap='hot')
+            plt.pause(0.00001)
+
         print(
             f"Episode #{episode} complete with a total reward of {round(total_episode_reward, 2)}. Target found? {terminated}"
         )
 
-        # display perceived values
-        q_ax[0].cla()
-        value_map = (Q.convert_to_np_arr(Ss + (As,), 100, int)).max(axis=2).transpose()
-        q_ax[0].set_title('perceived state values (max Q values)')
-        q_ax[1].set_title('agent heat map')
-        q_ax[0].imshow(value_map)
-        q_ax[1].imshow(heatmap, cmap='hot', interpolation='nearest')
-        plt.pause(0.0001)
 
+
+    plt.pause(10)
     env.close()
 
 

--- a/naive.py
+++ b/naive.py
@@ -1,0 +1,112 @@
+import gym
+import gym_env
+import numpy as np
+import random
+import tables
+from matplotlib import pyplot as plt
+
+
+MAX_EPISODES = 25
+MAX_TRY = 5000
+
+# figure window for perceived values
+q_fig, q_ax = plt.subplots(1, 2)
+plt.ion()
+
+
+def model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon):
+
+    # Create and initialize arrays
+    Q = tables.StateActionTable(default_value=100)
+    R = tables.StateActionTable(default_value=0)
+    C = tables.StateActionTable(default_value=0)
+    T = tables.TTable()
+    q_updates_count = 0
+
+    heatmap = np.full((Ss[1], Ss[0]), fill_value=0, dtype=int)
+
+    for episode in range(MAX_EPISODES):
+        total_episode_reward = 0
+
+        curr_state, _ = env.reset()
+
+        for t in range(MAX_TRY):
+
+            # select action
+            if random.uniform(0, 1) < epsilon:
+                action = env.action_space.sample()
+            else:
+                action = Q.get_best_action(state=tuple(curr_state), actions=[0, 1, 2, 3])
+
+            # execute action
+            next_state, reward, terminated, truncated, info = env.step(action)
+            heatmap[next_state[1], next_state[0]] += 1
+            total_episode_reward += reward
+
+            # update T, C, and R tables
+            T[tuple(curr_state), action, tuple(next_state)] += 1
+            C[tuple(curr_state), action] += 1
+            R[tuple(curr_state), action] += (reward - R[tuple(curr_state), action]) / C[tuple(curr_state), action]
+
+            # update Q tables
+            # naive implementation - super inefficient and slow
+            # updates every entry of the Q table after every action
+            # (a literal implementation of fig 12.6 from https://artint.info/2e/html/ArtInt2e.Ch12.S8.html)
+            for (x1, y1) in C.get_all_states():
+                for act in range(4):
+                    if C[(x1, y1), act] == 0:
+                        continue
+
+                    Q[(x1, y1), act] = R[(x1, y1), act]
+
+                    for (x2, y2) in T.get_states_accessible_from((x1, y1)):
+                        Q[(x1, y1), act] += discount_factor * (T[(x1, y1), act, (x2, y2)] / C[(x1, y1), act]) * \
+                                max(Q.get_action_values(state=(x2, y2), actions=[0, 1, 2, 3]).values())
+                        q_updates_count += 1
+
+            curr_state = next_state
+
+            if terminated or t >= MAX_TRY:
+                break
+
+            # display perceived values
+            q_ax[0].cla()
+            q_ax[1].cla()
+            value_map = (Q.convert_to_np_arr(Ss + (As,), 100)).max(axis=2).transpose()
+            q_ax[0].set_title('perceived state values (max Q values)')
+            q_ax[1].set_title('agent heat map')
+            q_ax[0].imshow(value_map)
+            q_ax[1].imshow(heatmap, cmap='hot')
+            plt.pause(0.00001)
+
+        print(
+            f"Episode #{episode} complete with a total reward of {round(total_episode_reward, 2)}. Target found? {terminated}. Q table accesses is at {q_updates_count}"
+        )
+
+
+
+    plt.pause(10)
+    env.close()
+
+
+"""
+MAIN DRIVER
+"""
+env = gym.make("gym_env/GridWorld-v0", render_mode="human")
+env.action_space.seed(42)
+
+# Set of states
+Ss = tuple(
+    (env.observation_space.high + np.ones(env.observation_space.shape)).astype(int)
+)
+
+# Set of actions
+As = env.action_space.n
+
+discount_factor = 0.9
+
+# Value to determine whether or not the agent explores more or not. 
+# i.e., a higher epsilon == more exploring
+epsilon = 0.1
+
+model_based_reinforcement_learner(env, Ss, As, discount_factor, epsilon)

--- a/pqueue.py
+++ b/pqueue.py
@@ -1,0 +1,52 @@
+class StateActionPQueue:
+    """
+    A priority queue of state, action pairs. 
+    Follows the format (STATE, ACTION, PRIORITY) where STATE is a tuple (x, y).
+    
+    Inspired from https://www.geeksforgeeks.org/priority-queue-in-python/.
+
+    Example usage:
+        PQueue = StateActionPQueue()
+        PQueue.insert((1,1), 2, 5)
+        while not PQueue.is_empty():
+            print(PQueue.pop())
+    """
+
+    def __init__(self):
+        self.queue = []
+
+    def __str__(self):
+        return ' '.join([str(i) for i in self.queue])
+
+    def is_empty(self):
+        return len(self.queue) == 0
+
+    # inserts a (state, action, priority) triple 
+    def insert(self, state, action, priority):
+        self.queue.append((state, action, priority))
+
+    # finds the value with the max priority and removes it from the queue
+    def pop(self):
+        try:
+            max_val = 0
+            for i in range(len(self.queue)):
+                if self.queue[i][2] > self.queue[max_val][2]:
+                    max_val = i
+            item = self.queue[max_val]
+            del self.queue[max_val]
+            return item
+        except IndexError:
+            exit()
+
+if __name__ == '__main__':
+    PQueue = StateActionPQueue()
+    PQueue.insert((1, 1), 2, 5)
+    PQueue.insert((1, 2), 1, 6)
+    PQueue.insert((3, 4), 0, 1)
+    PQueue.insert((4, 1), 3, 3)
+    print(PQueue, "\n")
+
+    print("Popping off values:")
+    print("(STATE, ACTION, PRIORITY)")
+    while not PQueue.is_empty():
+        print(PQueue.pop())

--- a/pqueue.py
+++ b/pqueue.py
@@ -19,7 +19,10 @@ class StateActionPQueue:
         return ' '.join([str(i) for i in self.queue])
 
     def __check_state_action_exists(self, state, action):
-        return [x for x in self.queue if x[0] == state and x[1] == action]
+        for s, a, _ in self.queue:
+            if s == state and a == action:
+                return True
+        return False
 
     def is_empty(self):
         return len(self.queue) == 0

--- a/pqueue.py
+++ b/pqueue.py
@@ -18,12 +18,16 @@ class StateActionPQueue:
     def __str__(self):
         return ' '.join([str(i) for i in self.queue])
 
+    def __check_state_action_exists(self, state, action):
+        return [x for x in self.queue if x[0] == state and x[1] == action]
+
     def is_empty(self):
         return len(self.queue) == 0
 
     # inserts a (state, action, priority) triple 
     def insert(self, state, action, priority):
-        self.queue.append((state, action, priority))
+        if not self.__check_state_action_exists(state=state, action=action):
+            self.queue.append((state, action, priority))
 
     # finds the value with the max priority and removes it from the queue
     def pop(self):

--- a/tables.py
+++ b/tables.py
@@ -93,9 +93,20 @@ class TTable:
         """
         returns states that have access to the specified state (inferred from table entries)
         :param state: state to infer predecessor states for
-        :return: list of states
+        :return: set of states
         """
         return set(itertools.chain(*[x.keys() for x in self.backward_map[state].values()]))
+
+    def get_state_actions_with_access_to(self, state):
+        """
+        returns state-action tuples that have given access to the specified state (inferred from table entries)
+        :param state: state to infer predecessor states for
+        :return: generator of state-action tuples
+        """
+        return itertools.chain(
+            *[itertools.product(s1, (act, )) for act, s1 in self.backward_map[state].items()]
+        )
+
 
 if __name__ == '__main__':
     # use StateActionTable class for Q, R, C tables
@@ -112,5 +123,7 @@ if __name__ == '__main__':
     T['s1', 'a1', 's2'] += 1
     T['s1', 'a2', 's3'] += 1
     T['s1', 'a1', 's4'] += 1
+    T['s3', 'a1', 's2'] += 1
+    T['s4', 'a3', 's2'] += 1
     print('states accessible from s1: ', T.get_states_accessible_from('s1'))
-    print('states with access to s3: ', T.get_states_with_access_to('s3'))
+    print('state-actions with access to s3: ', [x for x in T.get_states_with_access_to('s2')])

--- a/tables.py
+++ b/tables.py
@@ -1,0 +1,90 @@
+import itertools
+
+
+class StateActionTable:
+    """
+    A table of values that can be looked up by state and action.
+    Example usage:
+        Q = StateActionTable(default_value=10)
+        Q['s1', 'a1'] = 5.2
+        Q['s1', 'a2'] = 2
+        print(Q['s2', 'a5'])  # prints 10
+    """
+
+    def __init__(self, default_value):
+        self.default_value = default_value
+        self.table = dict()
+
+    def __getitem__(self, item):
+        return self.table.get(item[0], dict()).get(item[1], self.default_value)
+
+    def __setitem__(self, key, value):
+        self.table.setdefault(key[0], dict())[key[1]] = value
+
+    def get_action_values(self, state, actions):
+        """
+        get dict of action values for the specified state
+        :param state: state to get action values for
+        :param actions: list of actions of interest
+        :return: dictionary of action -> value
+        """
+        return {action: self[state, action] for action in actions}
+
+
+class TTable:
+    """
+    A table of values that can be looked up by state, action, and next state
+    can infer both successor and predecessor states for a given state
+    Example usage:
+        T = TTable()
+        T['s1', 'a1', 's2'] += 1
+        T['s1', 'a2', 's3'] += 1
+        T['s1', 'a1', 's4'] += 1
+        T.get_states_accessible_from('s1')  # returns ['s2', 's4', 's3']
+        T.get_states_with_access_to('s3')  # returns ['s1']
+    """
+
+    def __init__(self):
+        self.forward_map = dict()
+        self.backward_map = dict()
+
+    def __getitem__(self, item):
+        return self.forward_map.get(item[0], dict()).get(item[1], dict()).get(item[2], 0)
+
+    def __setitem__(self, key, value):
+        self.forward_map.setdefault(key[0], dict()).setdefault(key[1], dict())[key[2]] = value
+        self.backward_map.setdefault(key[2], dict()).setdefault(key[1], dict())[key[0]] = value
+
+    def get_states_accessible_from(self, state):
+        """
+        returns states that can be accessed from the specified state (inferred from table entries)
+        :param state: state to infer successor states for
+        :return: list of states
+        """
+        return list(itertools.chain(*[x.keys() for x in self.forward_map[state].values()]))
+
+    def get_states_with_access_to(self, state):
+        """
+        returns states that have access to the specified state (inferred from table entries)
+        :param state: state to infer predecessor states for
+        :return: list of states
+        """
+        return list(itertools.chain(*[x.keys() for x in self.backward_map[state].values()]))
+
+
+# use StateActionTable class for Q, R, C tables
+R = StateActionTable(default_value=10)
+R['s1', 'a1'] = 5.2
+R['s1', 'a2'] += 2
+print('R entry for s1, a1: ', R['s1', 'a1'])
+print('R entry for s2, a2: ', R['s1', 'a2'])
+print('R entries for s1, actions a1-a3: ', R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']))
+print(max(R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']), key=R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']).get))
+
+# use TTable class for the T table
+T = TTable()
+T['s1', 'a1', 's2'] += 1
+T['s1', 'a2', 's3'] += 1
+T['s1', 'a1', 's4'] += 1
+print('states accessible from s1: ', T.get_states_accessible_from('s1'))
+print('states with access to s3: ', T.get_states_with_access_to('s3'))

--- a/tables.py
+++ b/tables.py
@@ -103,9 +103,12 @@ class TTable:
         :param state: state to infer predecessor states for
         :return: generator of state-action tuples
         """
-        return itertools.chain(
-            *[itertools.product(s1, (act, )) for act, s1 in self.backward_map[state].items()]
-        )
+        try:
+            return itertools.chain(
+                *[itertools.product(s1, (act, )) for act, s1 in self.backward_map[state].items()]
+            )
+        except KeyError:
+            return []
 
 
 if __name__ == '__main__':

--- a/tables.py
+++ b/tables.py
@@ -31,10 +31,22 @@ class StateActionTable:
         return {action: self[state, action] for action in actions}
 
     def get_best_action(self, state, actions):
+        """
+        get best action to take for a specified state
+        :param state: state to get action values for
+        :param actions: list of actions of interest
+        :return: the best action (key with the highest value)
+        """
         action_values = self.get_action_values(state=state, actions=actions)
         return max(action_values, key=action_values.get)
 
     def convert_to_np_arr(self, size, fill_value):
+        """
+        converts a StateActionTable to numpy array
+        :param size: size of the numpy array
+        :param fill_value: value to initialize array with
+        :return: the equivalent numpy array
+        """
         arr = np.full(size, fill_value=fill_value)
         for (x, y) in list(self.table.keys()):
             for act, act_value in enumerate(list(self.get_action_values((x, y), [0, 1, 2, 3]).values())):

--- a/tables.py
+++ b/tables.py
@@ -34,12 +34,16 @@ class StateActionTable:
         action_values = self.get_action_values(state=state, actions=actions)
         return max(action_values, key=action_values.get)
 
-    def convert_to_np_arr(self, size, fill_value, dtype):
-        arr = np.full(size, fill_value=fill_value, dtype=dtype)
+    def convert_to_np_arr(self, size, fill_value):
+        arr = np.full(size, fill_value=fill_value)
         for (x, y) in list(self.table.keys()):
             for act, act_value in enumerate(list(self.get_action_values((x, y), [0, 1, 2, 3]).values())):
                 arr[x, y, act] = act_value
         return arr
+
+    def get_all_states(self):
+        return self.table.keys()
+
 
 class TTable:
     """
@@ -71,7 +75,7 @@ class TTable:
         :param state: state to infer successor states for
         :return: list of states
         """
-        return list(itertools.chain(*[x.keys() for x in self.forward_map[state].values()]))
+        return set(itertools.chain(*[x.keys() for x in self.forward_map[state].values()]))
 
     def get_states_with_access_to(self, state):
         """
@@ -79,7 +83,7 @@ class TTable:
         :param state: state to infer predecessor states for
         :return: list of states
         """
-        return list(itertools.chain(*[x.keys() for x in self.backward_map[state].values()]))
+        return set(itertools.chain(*[x.keys() for x in self.backward_map[state].values()]))
 
 if __name__ == '__main__':
     # use StateActionTable class for Q, R, C tables

--- a/tables.py
+++ b/tables.py
@@ -30,6 +30,10 @@ class StateActionTable:
         """
         return {action: self[state, action] for action in actions}
 
+    def get_best_action(self, state, actions):
+        action_values = self.get_action_values(state=state, actions=actions)
+        return max(action_values, key=action_values.get)
+
 
 class TTable:
     """
@@ -71,20 +75,20 @@ class TTable:
         """
         return list(itertools.chain(*[x.keys() for x in self.backward_map[state].values()]))
 
+if __name__ == '__main__':
+    # use StateActionTable class for Q, R, C tables
+    R = StateActionTable(default_value=10)
+    R['s1', 'a1'] = 5.2
+    R['s1', 'a2'] += 2
+    print('R entry for s1, a1: ', R['s1', 'a1'])
+    print('R entry for s2, a2: ', R['s1', 'a2'])
+    print('R entries for s1, actions a1-a3: ', R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']))
+    print('Best action choice (max):', R.get_best_action(state='s1', actions=['a1', 'a2', 'a3']))
 
-# use StateActionTable class for Q, R, C tables
-R = StateActionTable(default_value=10)
-R['s1', 'a1'] = 5.2
-R['s1', 'a2'] += 2
-print('R entry for s1, a1: ', R['s1', 'a1'])
-print('R entry for s2, a2: ', R['s1', 'a2'])
-print('R entries for s1, actions a1-a3: ', R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']))
-print(max(R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']), key=R.get_action_values(state='s1', actions=['a1', 'a2', 'a3']).get))
-
-# use TTable class for the T table
-T = TTable()
-T['s1', 'a1', 's2'] += 1
-T['s1', 'a2', 's3'] += 1
-T['s1', 'a1', 's4'] += 1
-print('states accessible from s1: ', T.get_states_accessible_from('s1'))
-print('states with access to s3: ', T.get_states_with_access_to('s3'))
+    # use TTable class for the T table
+    T = TTable()
+    T['s1', 'a1', 's2'] += 1
+    T['s1', 'a2', 's3'] += 1
+    T['s1', 'a1', 's4'] += 1
+    print('states accessible from s1: ', T.get_states_accessible_from('s1'))
+    print('states with access to s3: ', T.get_states_with_access_to('s3'))

--- a/tables.py
+++ b/tables.py
@@ -1,5 +1,5 @@
 import itertools
-
+import numpy as np
 
 class StateActionTable:
     """
@@ -34,6 +34,12 @@ class StateActionTable:
         action_values = self.get_action_values(state=state, actions=actions)
         return max(action_values, key=action_values.get)
 
+    def convert_to_np_arr(self, size, fill_value, dtype):
+        arr = np.full(size, fill_value=fill_value, dtype=dtype)
+        for (x, y) in list(self.table.keys()):
+            for act, act_value in enumerate(list(self.get_action_values((x, y), [0, 1, 2, 3]).values())):
+                arr[x, y, act] = act_value
+        return arr
 
 class TTable:
     """


### PR DESCRIPTION
### What's happening in this PR?
This PR will introduce a replacement to numpy arrays with the ADT's from `tables.py`. Once that is all working properly, prioritized sweeping will be implemented rather than the current implementation.

### Bugs
<details>
<summary>Resolved Bugs</summary>
<br />
- There seems to be an issue with plotting the perceived state values (max Q values) as compared to what happens on the `main` branch. It seems as if the Q values once converted from the StateActionTable to a numpy array are different than what would appear just by using a numpy array.<br /><br />

`value_map` output on this branch (after 24 episodes):
<img width="562" alt="Screenshot 2022-11-16 at 1 13 34 PM" src="https://user-images.githubusercontent.com/63923438/202284584-0b26a06d-69f7-47f2-b1ed-ef6b473d64ad.png">

`value_map` output on `main` (after 24 episodes):
<img width="562" alt="Screenshot 2022-11-16 at 1 15 45 PM" src="https://user-images.githubusercontent.com/63923438/202285032-4d6d29b9-5f80-4a17-a08e-188d473366a8.png">
</details>

### How do I test it myself?
1. Clone the repository and cd into it.
```
git clone https://github.com/echalmers/state_abstraction_rl.git
cd state_abstration_rl
``` 
2. Checkout this branch
```
git checkout prioritized-sweeping
```
3. Run the following command to set up the `gym-env` custom environment. 
**NOTE: You need to do this every time you close/re-open your terminal. The python virtual environment is temporary only for your current terminal session.**
```
cd gym_env && python3 -m venv .env && source .env/bin/activate && pip3 install -e . && cd ..
```
4. Try it out!
```
python3 main.py
```

### NOTE:
These instructions are for Mac, so you *may* need to use `python` rather than `python3` if you're on windows. 