### PR TITLE
Use`imageio` to convert bitmaps into environments for grid worlds

### DIFF
--- a/mbrl_driver.py
+++ b/mbrl_driver.py
@@ -9,7 +9,7 @@ import astar
 IMAGE_FOLDER = 'images/'
 MAX_EPISODES = 25
 MAX_TRY = 5000
-discount_factor = 0.9
+discount_factor = 0.99
 
 # for priorities
 theta_threshold = 0.01

--- a/mbrl_driver.py
+++ b/mbrl_driver.py
@@ -1,10 +1,12 @@
 import gym
 import mbrl
 import pygame_envs
+import imageio.v2 as iio
 import numpy as np
 import time
 import astar
 
+IMAGE_FOLDER = 'images/'
 MAX_EPISODES = 25
 MAX_TRY = 5000
 discount_factor = 0.9
@@ -16,8 +18,12 @@ theta_threshold = 0.01
 # i.e., a higher epsilon == more exploring
 epsilon = 0.1
 
-# create environment
-env = gym.make("GridWorld-v0", render_mode='human', size=(48, 17))
+# Choose bitmap for environment
+im = iio.imread(IMAGE_FOLDER + input("Enter the bitmap filename: "))
+height, width  = im.shape
+
+# Create environment
+env = gym.make("GridWorld-v0", img=im, render_mode='human', size=(width, height))
 
 # Initialize the model-based reinforcement learner
 mbrl = mbrl.MBRL(

--- a/pygame_envs/envs/grid_world.py
+++ b/pygame_envs/envs/grid_world.py
@@ -17,13 +17,13 @@ BLACK = (0, 0, 0)
 class GridWorldEnv(gym.Env):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 100000}
 
-    def __init__(self, render_mode=None, size=(48, 17), block_size=20):
+    def __init__(self, img, target_location=(45, 11), render_mode=None, size=(48, 17), block_size=20):
         self.size_x = size[0]
         self.size_y = size[1]
         self.block_size = block_size
         self.window_width = self.size_x * self.block_size
         self.window_height = self.size_y * self.block_size
-
+        self.img = img
         self.observation_space = spaces.Box(np.array([0, 0]), np.array([self.size_x, self.size_y]), dtype=int)
 
         # 4 actions, corresponding to "right", "up", "left", "down", "right"
@@ -126,6 +126,7 @@ class GridWorldEnv(gym.Env):
 
         canvas = pygame.Surface((self.window_width, self.window_height))
         canvas.fill((255, 255, 255))
+
         pix_square_size = (
             self.block_size
         )  # The size of a single grid square in pixels
@@ -148,14 +149,17 @@ class GridWorldEnv(gym.Env):
             pix_square_size / 3,
         )
 
-        # Draw gridlines
-        for x in range (0, self.window_width, self.block_size):
+        for x in range(0, self.window_width, self.block_size):
             for y in range(0, self.window_height, self.block_size):
-                if y == 0 or x == 0 or y == (self.window_height - self.block_size) or x == (self.window_width - self.block_size):
-                    rect = pygame.Rect(x, y, self.block_size, self.block_size)
-                    pygame.draw.rect(canvas, BLUE, rect)
-                
                 rect = pygame.Rect(x, y, self.block_size, self.block_size)
+
+                _x = int(x / self.block_size)
+                _y = int(y / self.block_size)
+
+                # Draw walls
+                if self.img[_y][_x] == 0:
+                    pygame.draw.rect(canvas, BLUE, rect)
+
                 pygame.draw.rect(canvas, BLACK, rect, 1)
 
         # Draw best path if its passed in

--- a/pygame_envs/envs/grid_world.py
+++ b/pygame_envs/envs/grid_world.py
@@ -85,12 +85,11 @@ class GridWorldEnv(gym.Env):
     def step(self, action):
         # Map the action (element of {0,1,2,3}) to the direction we walk in
         direction = self._action_to_direction[action]
-        old_location = self._agent_location
-        
-        # We use `np.clip` to make sure we don't leave the grid
-        self._agent_location = np.clip(
-            self._agent_location + direction, [1, 1], [self.size_x - 2, self.size_y - 2]
-        )
+        next_cell = self._agent_location + direction
+
+        # Only move agent if next cell is not a wall
+        if self.img[next_cell[1]][next_cell[0]] != 0:
+            self._agent_location = self._agent_location + direction
 
         # An episode is done iff the agent has reached the target
         terminated = np.array_equal(self._agent_location, self._target_location)
@@ -98,9 +97,8 @@ class GridWorldEnv(gym.Env):
         observation = self._get_obs()                     
         info = self._get_info()
 
-        if self.img[self._agent_location[1]][self._agent_location[0]] == 0: # if agent hits a wall
+        if self.img[next_cell[1]][next_cell[0]] == 0: # if agent hits a wall
             reward = -0.1
-            self._agent_location = old_location
         elif terminated:
             reward = 10
         else:
@@ -110,7 +108,7 @@ class GridWorldEnv(gym.Env):
             self._render_frame()
 
         self.heatmap[observation[1], observation[0]] += 1
-            
+        
         return observation, reward, terminated, False, info
 
     def render(self):

--- a/pygame_envs/envs/grid_world.py
+++ b/pygame_envs/envs/grid_world.py
@@ -89,7 +89,7 @@ class GridWorldEnv(gym.Env):
         
         # We use `np.clip` to make sure we don't leave the grid
         self._agent_location = np.clip(
-            self._agent_location + direction, [1, 1], [self.size_x - 2, self.size_y - 2]
+            self._agent_location + direction, [0, 0], [self.size_x - 1, self.size_y - 1]
         )
 
         # An episode is done iff the agent has reached the target
@@ -98,8 +98,9 @@ class GridWorldEnv(gym.Env):
         observation = self._get_obs()                     
         info = self._get_info()
 
-        if (old_location == self._agent_location).all(): # if agent hits a wall
+        if self.img[self._agent_location[1]][self._agent_location[0]] == 0: # if agent hits a wall
             reward = -0.1
+            self._agent_location = old_location
         elif terminated:
             reward = 10
         else:

--- a/pygame_envs/envs/grid_world.py
+++ b/pygame_envs/envs/grid_world.py
@@ -89,7 +89,7 @@ class GridWorldEnv(gym.Env):
         
         # We use `np.clip` to make sure we don't leave the grid
         self._agent_location = np.clip(
-            self._agent_location + direction, [0, 0], [self.size_x - 1, self.size_y - 1]
+            self._agent_location + direction, [1, 1], [self.size_x - 2, self.size_y - 2]
         )
 
         # An episode is done iff the agent has reached the target

--- a/pygame_envs/envs/grid_world.py
+++ b/pygame_envs/envs/grid_world.py
@@ -17,7 +17,7 @@ BLACK = (0, 0, 0)
 class GridWorldEnv(gym.Env):
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 100000}
 
-    def __init__(self, img, target_location=(45, 11), render_mode=None, size=(48, 17), block_size=20):
+    def __init__(self, img, render_mode=None, size=(48, 17), block_size=20):
         self.size_x = size[0]
         self.size_y = size[1]
         self.block_size = block_size


### PR DESCRIPTION
This PR allows grid world environments to be created purely from a bitmap image, allowing for more dynamic environments. An issue arises with wall collisions that is discussed below:

## Issues
1) Wall collisions. Currently, `np.clip` is used to make sure the agent stays within the boundary of the grid_world:
```python
self._agent_location = np.clip(
    self._agent_location + direction, [1, 1], [self.size_x - 2, self.size_y - 2]
)
```
Since this is set to a boundary from `(1,1)` to `(x - 2, y - 2)`, the agent does not collide with the outside walls producing a reward of `-0.1`. This can be fixed by changing the boundary to `(0, 0)` and `(x - 1, y - 1)` but it also introduces some different behaviour by the agent. 

## Potential Solutions
1) Currently, I have the `np.clip` remaining as `(1, 1) to `(x - 2)(y - 2)` as outside boundaries seem to be fine the way they are (keeps the agent within the "walls") but I introduced some checks for inside boundaries if we were to introduce an environment with interior walls. 